### PR TITLE
Fixes #5: Subclass RequestError to connection, http and parse errors; handle them

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ Use bundled classes (StreamReader):
         console.log(output.toString());
       }
 
-Use bundled classes (StreamReader):
+Use bundled classes (superclass RequestError, or specifics ConnectionError,
+HTTPError, ParseError):
 
-    var error = new request.RequestError('I'm a teapot!', 417, 'teapot');
+    var error = new request.HTTPError('I'm a teapot!', 417, 'teapot');
+    throw new request.ParseError(`Invalid JSON: '${body}'`, error.message);
 
 ### Supported options
 
@@ -67,46 +69,67 @@ const defaults = {
 A few tests have been written, with a few options supported. Here's a result of a test run:
 
 ```
-  RequestError
-    ✓ Supports message, status code and response
-    ✓ Stringifies to a meaningful message
+ParseError
+  ✓ Supports message, status code and response
+  ✓ is an an instance of RequestError
 
-  Request - test against httpbin.org
-    ✓ Supports HTTP (290ms)
-    ✓ Supports HTTPS (556ms)
-    - Supports HTTP as the default protocol (if none given)
-    ✓ Supports query string parameters in URL (393ms)
-    ✓ Supports booleans, strings, and numbers in query object (400ms)
-    ✓ Accepts custom headers (399ms)
-    - Interprets empty response with JSON request as null
-    ✓ Supports 301-303 redirects (775ms)
-    ✓ Rejects on 4xx errors (257ms)
-    ✓ Limits the maximum number of 301-303 redirects (388ms)
-    ✓ Performs POST requests (260ms)
-    ✓ Performs PUT requests (276ms)
-    ✓ Performs DELETE requests (269ms)
-    ✓ Supports TLS with passphrase
-    ✓ Supports HTTP Basic Auth (387ms)
-    ✓ Supports GZIP compression (388ms)
-    ✓ Supports null options (399ms)
-    ✓ Supports 'json' in options (268ms)
-    ✓ Supports 'form' in options (x-www-form-urlencoded) (255ms)
-    ✓ Supports 'resolveWithFullResponse' in options (262ms)
-    - Supports 'multipart' bodies
-    ✓ Supports 'verbose' in options (297ms)
+HTTPError
+  ✓ Supports message, status code and response
+  ✓ Stringifies to a meaningful message
+  ✓ is an an instance of RequestError
 
-  StreamReader
-    ✓ Reads a stream fully
-    - Fails gracefully on invalid stream
+ConnectionError
+  ✓ Supports message and raw message
+  ✓ Stringifies to a meaningful message
+  ✓ is an an instance of RequestError
 
-  index.js wrapper
-    ✓ Nested methods - request.get (256ms)
-    ✓ Nested classes - request.Request (379ms)
-    ✓ Nested classes - request.StreamReader
+Request - test against httpbin.org
+  ✓ Supports HTTP (269ms)
+  ✓ Supports HTTPS (635ms)
+  - Supports HTTP as the default protocol (if none given)
+  ✓ Supports query string parameters in URL (390ms)
+  ✓ Supports booleans, strings, and numbers in query object (403ms)
+  ✓ Accepts custom headers (436ms)
+  - Interprets empty response with JSON request as null
+  ✓ Supports 301-303 redirects (784ms)
+  ✓ Rejects on 4xx errors (258ms)
+  ✓ Limits the maximum number of 301-303 redirects (434ms)
+  ✓ Performs POST requests (271ms)
+  ✓ Performs PUT requests (255ms)
+  ✓ Performs DELETE requests (246ms)
+  ✓ Supports TLS with passphrase
+  ✓ Supports HTTP Basic Auth (400ms)
+  ✓ Supports GZIP compression (479ms)
+  ✓ Supports null options (379ms)
+  ✓ Supports 'json' in options (265ms)
+  ✓ Supports 'form' in options (x-www-form-urlencoded) (263ms)
+  ✓ Supports 'resolveWithFullResponse' in options (254ms)
+  - Supports 'multipart' bodies
+  ✓ Supports 'verbose' in options (258ms)
+
+Error handling
+  ✓ Throws TypeError when constructing with an invalid method
+  ✓ Throws TypeError when constructing with an invalid query string
+  ✓ Throws TypeError when constructing with an invalid protocol
+  ✓ Throws TypeError when constructing with an invalid path
+  ✓ Throws connections to non-existing hosts as ConnectionError
+  ✓ Throws ConnectionError when client aborted
+  ✓ Throws ConnectionError when server aborted
+  ✓ Throws ConnectionError on other errors
+  ✓ Throws ParseError when requesting JSON, but getting sth else (289ms)
+
+StreamReader
+  ✓ Reads a stream fully
+  - Fails gracefully on invalid stream
+
+index.js wrapper
+  ✓ Nested methods - request.get (253ms)
+  ✓ Nested classes - request.Request (385ms)
+  ✓ Nested classes - request.StreamReader
 
 
-  25 passing (7s)
-  4 pending
+40 passing (8s)
+4 pending
 ```
 
 ## Building

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "jsonpath": "^0.2.2",
     "minimist": "^1.2.0",
     "mocha": "^2.4.5",
+    "proxyquire": "^1.7.10",
     "sinon": "^1.17.3",
     "source-map-support": "^0.4.0"
   },

--- a/src/ConnectionError.js
+++ b/src/ConnectionError.js
@@ -1,0 +1,23 @@
+import RequestError from './RequestError';
+
+/**
+ * @typedef {Object} ConnectionError
+ *
+ * RequestError with Connection specific semantics
+ *
+ * @extends RequestError
+ */
+export default class ConnectionError extends RequestError {
+
+  /**
+   * RequestError with HTTP Semantics
+   *
+   * @param {string} message Human readable error message
+   * @param {string} the raw UNIX message that originated this error
+   */
+  constructor(message, rawMessage) {
+    super(message);
+
+    this.rawMessage = rawMessage;
+  }
+}

--- a/src/HTTPError.js
+++ b/src/HTTPError.js
@@ -1,0 +1,32 @@
+import RequestError from './RequestError';
+
+/**
+ * RequestError with HTTP Semantics
+ *
+ * @extends RequestError
+ */
+export default class HTTPError extends RequestError {
+
+  /**
+   * RequestError with HTTP Semantics
+   *
+   * @param {string} message Human readable error message
+   * @param {number} statusCode HTTP status code
+   * @param {object} response The raw response or body
+   */
+  constructor(message, statusCode, response) {
+    super(message);
+
+    this.statusCode = statusCode;
+    this.response = response;
+  }
+
+  /**
+   * The default constructor: Saves the element data
+   *
+   * @return {string} String in format <statuscode>: <message>
+   */
+  toString() {
+    return this.statusCode + ': ' + this.message;
+  }
+}

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -1,0 +1,23 @@
+import RequestError from './RequestError';
+
+/**
+ * @typedef {Object} SocketError
+ *
+ * RequestError with error parsing semantics
+ *
+ * @extends RequestError
+ */
+export default class ParseError extends RequestError {
+
+  /**
+   * RequestError with parsing semantics
+   *
+   * @param {string} message Human readable error message
+   * @param {string} the raw UNIX message that originated this error
+   */
+  constructor(message, rawMessage) {
+    super(message);
+
+    this.rawMessage = rawMessage;
+  }
+}

--- a/src/RequestError.js
+++ b/src/RequestError.js
@@ -1,38 +1,18 @@
 /**
- * A type-safe error that is sent on request failures.
+ * @typedef {Object} RequestError
  *
- * Contains status code, error message and the request with its data.
+ * A type-safe error that is sent on request failures. Do not use this directly.
+ * This is an abstract class - use HTTPError, ConnectionError or ParseError,
+ * instead.
  *
  * @extends Error
  */
 export default class RequestError extends Error {
 
   /**
-   * The default constructor: Saves the element data.
-   *
-   * This class takes no stance on what is passed into Response.
-   * In case Request was called with 'resolveWithFullResponse', this
-   * value is likely the full response. Otherwise it is likely the body.
-   *
-   * @param {string} message Human readable error message
-   * @param {number} statusCode HTTP status code
-   * @param {object} response The raw response or body
-   */
-  constructor(message, statusCode, response) {
-    super(message);
-
-    this.statusCode = statusCode;
-    this.response = response;
-  }
-
-  /**
-   * The default constructor: Saves the element data
-   *
-   * FIXME For some reason toString cannot be overriden.
-   *
-   * @return {string} String in format <statuscode>: <message>
+   * @return {string} the message - as-is
    */
   toString() {
-    return this.statusCode + ': ' + this.message;
+    return this.message;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 import Request from './Request';
 import StreamReader from './StreamReader';
 import RequestError from './RequestError';
+import ConnectionError from './ConnectionError';
+import HTTPError from './HTTPError';
+import ParseError from './ParseError';
 
 /**
  * Default handler that creates a new client and executes it
@@ -19,4 +22,7 @@ export default {
   Request: Request,
   StreamReader: StreamReader,
   RequestError: RequestError,
+  ConnectionError: ConnectionError,
+  HTTPError: HTTPError,
+  ParseError: ParseError,
 };

--- a/test/RequestErrorSpec.js
+++ b/test/RequestErrorSpec.js
@@ -4,21 +4,64 @@
 
 const expect = require('chai').expect;
 const RequestError = require('../lib/RequestError');
+const ConnectionError = require('../lib/ConnectionError');
+const HTTPError = require('../lib/HTTPError');
+const ParseError = require('../lib/ParseError');
 
-describe('RequestError', () => {
-
+describe('ParseError', () => {
   const message = 'foo';
-  const status = 303;
-  const response = { foo: 'bar' };
-  const error = new RequestError(message, status, response);
+  const rawMessage = 'raw';
+
+  const error = new ParseError(message, rawMessage);
 
   it('Supports message, status code and response', () => {
     expect(error.message).to.equal(message);
-    expect(error.statusCode).to.equal(status);
+    expect(error.rawMessage).to.equal(rawMessage);
+  });
+
+  it('is an an instance of RequestError', () => {
+    expect(error).to.be.instanceof(RequestError);
+  });
+});
+
+
+describe('HTTPError', () => {
+  const message = 'foo';
+  const statusCode = 303;
+  const response = { foo: 'bar' };
+  const error = new HTTPError(message, statusCode, response);
+
+  it('Supports message, status code and response', () => {
+    expect(error.message).to.equal(message);
+    expect(error.statusCode).to.equal(statusCode);
     expect(error.response).to.equal(response);
   });
 
   it('Stringifies to a meaningful message', () => {
     expect(error.toString()).to.match(/\d{3}:.+/);
+  });
+
+  it('is an an instance of RequestError', () => {
+    expect(error).to.be.instanceof(RequestError);
+  });
+});
+
+describe('ConnectionError', () => {
+  const message = 'foo';
+  const rawMessage = 'raw';
+
+  const error = new ConnectionError(message, rawMessage);
+
+  it('Supports message and raw message', () => {
+    expect(error.message).to.equal(message);
+    expect(error.rawMessage).to.equal(rawMessage);
+  });
+
+  it('Stringifies to a meaningful message', () => {
+    expect(error.toString()).to.equal(message);
+  });
+
+  it('is an an instance of RequestError', () => {
+    expect(error).to.be.instanceof(RequestError);
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 describe('request-promise-light', () => {
   require('./StreamReaderSpec.js');
-  require('./RequestSpec.js');
   require('./RequestErrorSpec.js');
+  require('./RequestSpec.js');
   require('./indexSpec.js');
 });


### PR DESCRIPTION
Before this, we could get a lot of unexpected runtime errors which we would need to parse manually (of type Error).

I have now subclassed the errors thrown by the promiseful part as follows:
- RequestError is the superclass for each of the errors
- ConnectionError deals with establishing & reading the connection (also streaming errors)
- HTTPErrors are the errors thrown by the server with the old RequestError semantics
- ParseErrors deal with invalid response data (e.g. expecting JSON but getting sth else)

The intention of this is the following: We can still catch all the errors specific to this library by doing instanceof RequestError checks, but we can also get the specifics.

The input when constructing Request is now parsed more diligently. *new Request() and correspondingly helpers request.get() will throw a TypeError if your request data is malformed*.
