### PR TITLE
Fix test to not depend on items order

### DIFF
--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -81,7 +81,8 @@ describe('Request - test against httpbin.org', () => {
         .then(response => {
           expect(response.statusCode).to.equal(200);
           expect(response.body).to.equal(null);
-          expect(response.headers.allow).to.equal('HEAD, OPTIONS, GET');
+          expect(response.headers.allow.split(', ').sort())
+            .to.deep.equal('HEAD, OPTIONS, GET'.split(', ').sort());
         });
   });
 


### PR DESCRIPTION
Tests failed on my side with:

```
AssertionError: expected 'OPTIONS, GET, HEAD' to equal 'HEAD, OPTIONS, GET'
      + expected - actual

      -OPTIONS, GET, HEAD
      +HEAD, OPTIONS, GET
```

It appears that order of items in `headers.allow` changed. This patch ensures that order is irrelevant