### PR TITLE
FIX #19 - Permit both custom logger and the simple verbose flag

### DIFF
--- a/src/ConsoleLogger.js
+++ b/src/ConsoleLogger.js
@@ -1,0 +1,24 @@
+import util from 'util';
+
+/**
+ * Default RPL logger implementation that echoes debug messages to console.
+ *
+ * This mainly exists as a sample on how to bind the RPL debug messages to
+ * whatever logging facility needed.
+ *
+ * Note that the implementation does not need to be a ES6 class - it can be a
+ * simple object that contains 'debug' function. Please note that this may be
+ * later extended to include other syslog level methods (such as info, warn
+ * etc.), if we ever get a use case.
+ */
+export default class ConsoleLogger {
+  /**
+   * Logs the debug level message.
+   *
+   * @param {...tokens} - The message strings or token values in the messages.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  debug(...tokens) {
+    console.info(util.format(...tokens));
+  }
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,9 +1,0 @@
-import util from 'util';
-
-const logger = {
-  log: (...tokens) => {
-    console.info(util.format(...tokens));
-  },
-};
-
-export default logger;

--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -12,7 +12,6 @@ const ParseError = require('../lib/ParseError');
 // See: https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
 
 describe('Request - test against httpbin.org', () => {
-
   let request;
   let url;
   let options;
@@ -24,35 +23,32 @@ describe('Request - test against httpbin.org', () => {
     url = 'http://httpbin.org/get';
     request = new Request('GET', url, { json: true });
 
-    return request.run()
-      .then(response => {
-        expect(response).to.exist;
-      });
+    return request.run().then(response => {
+      expect(response).to.exist;
+    });
   });
 
   it('Supports HTTPS', () => {
     url = 'https://httpbin.org/get';
     request = new Request('GET', url, { json: true });
 
-    return request.run()
-      .then(response => {
-        expect(response).to.exist;
-      });
+    return request.run().then(response => {
+      expect(response).to.exist;
+    });
   });
 
-    // Skipped as most of hte endpoints see TRACE calls as a security concern
+  // Skipped as most of hte endpoints see TRACE calls as a security concern
   xit('Performs TRACE requests', () => {
     url = 'http://httpbin.org/get';
     body = { foo: 'bar' };
     options = { json: true, body, resolveWithFullResponse: true };
     request = new Request('TRACE', url, options);
 
-      // Trace should echo whatever is sent back to the user with 200
-    return request.run()
-        .then(response => {
-          expect(response.statusCode).to.equal(200);
-          expect(JSON.parse(response.body).foo).to.equal('bar');
-        });
+    // Trace should echo whatever is sent back to the user with 200
+    return request.run().then(response => {
+      expect(response.statusCode).to.equal(200);
+      expect(JSON.parse(response.body).foo).to.equal('bar');
+    });
   });
 
   it('Performs HEAD requests', () => {
@@ -61,13 +57,12 @@ describe('Request - test against httpbin.org', () => {
     options = { json: true, body, resolveWithFullResponse: true };
     request = new Request('HEAD', url, options);
 
-      // HEAD should return a response header, identical to HTTP get.
-    return request.run()
-        .then(response => {
-          expect(response.statusCode).to.equal(200);
-          expect(response.body).to.equal(null);
-          expect(response.headers['content-type']).to.equal('application/json');
-        });
+    // HEAD should return a response header, identical to HTTP get.
+    return request.run().then(response => {
+      expect(response.statusCode).to.equal(200);
+      expect(response.body).to.equal(null);
+      expect(response.headers['content-type']).to.equal('application/json');
+    });
   });
 
   it('Performs OPTIONS requests', () => {
@@ -76,24 +71,23 @@ describe('Request - test against httpbin.org', () => {
     options = { json: true, body, resolveWithFullResponse: true };
     request = new Request('OPTIONS', url, options);
 
-      // HEAD should return a response header, identical to HTTP get.
-    return request.run()
-        .then(response => {
-          expect(response.statusCode).to.equal(200);
-          expect(response.body).to.equal(null);
-          expect(response.headers.allow.split(', ').sort())
-            .to.deep.equal('HEAD, OPTIONS, GET'.split(', ').sort());
-        });
+    // HEAD should return a response header, identical to HTTP get.
+    return request.run().then(response => {
+      expect(response.statusCode).to.equal(200);
+      expect(response.body).to.equal(null);
+      expect(response.headers.allow.split(', ').sort()).to.deep.equal(
+        'HEAD, OPTIONS, GET'.split(', ').sort()
+      );
+    });
   });
 
   it('Performs GET requests', () => {
     url = 'http://httpbin.org/get';
     request = new Request('GET', url, { json: true });
 
-    return request.run()
-        .then(response => {
-          expect(response).to.exist;
-        });
+    return request.run().then(response => {
+      expect(response).to.exist;
+    });
   });
 
   it('Performs POST requests', () => {
@@ -101,10 +95,9 @@ describe('Request - test against httpbin.org', () => {
     body = { foo: 'bar' };
     request = new Request('POST', url, { json: true, body });
 
-    return request.run()
-        .then(response => {
-          expect(JSON.parse(response.data).foo).to.equal('bar');
-        });
+    return request.run().then(response => {
+      expect(JSON.parse(response.data).foo).to.equal('bar');
+    });
   });
 
   it('Performs PUT requests', () => {
@@ -112,10 +105,9 @@ describe('Request - test against httpbin.org', () => {
     body = { foo: 'bar' };
     request = new Request('PUT', url, { json: true, body });
 
-    return request.run()
-        .then(response => {
-          expect(JSON.parse(response.data).foo).to.equal('bar');
-        });
+    return request.run().then(response => {
+      expect(JSON.parse(response.data).foo).to.equal('bar');
+    });
   });
 
   it('Performs PATCH requests', () => {
@@ -123,10 +115,9 @@ describe('Request - test against httpbin.org', () => {
     body = { foo: 'bar' };
     request = new Request('PATCH', url, { json: true, body });
 
-    return request.run()
-        .then(response => {
-          expect(JSON.parse(response.data).foo).to.equal('bar');
-        });
+    return request.run().then(response => {
+      expect(JSON.parse(response.data).foo).to.equal('bar');
+    });
   });
 
   it('Performs DELETE requests', () => {
@@ -134,44 +125,44 @@ describe('Request - test against httpbin.org', () => {
     body = { foo: 'bar' };
     request = new Request('DELETE', url, { json: true, body });
 
-    return request.run()
-        .then(response => {
-          expect(response).to.exist;
-        });
+    return request.run().then(response => {
+      expect(response).to.exist;
+    });
   });
 
   it('Fails with TypeError if no protocol given', () => {
     url = 'httpbin.org/get';
-    expect(() => new Request('GET', url, { json: true }))
-      .to.throw(TypeError);
+    expect(() => new Request('GET', url, { json: true })).to.throw(TypeError);
   });
 
   it('Fails with TypeError on invalid form data', () => {
     url = 'https://httpbin.org/get';
-    expect(() => new Request('POST', url, { form: 'invalidForm' }))
-      .to.throw(TypeError);
+    expect(() => new Request('POST', url, { form: 'invalidForm' })).to.throw(
+      TypeError
+    );
   });
 
   it('Fails with TypeError on invalid auth data', () => {
     url = 'https://httpbin.org/get';
-    expect(() => new Request('POST', url, { auth: 'invalidForm' }))
-      .to.throw(TypeError);
+    expect(() => new Request('POST', url, { auth: 'invalidForm' })).to.throw(
+      TypeError
+    );
   });
 
   it('Fails with TypeError on invalid compression scheme', () => {
     url = 'https://httpbin.org/get';
-    expect(() => new Request('POST', url, { compression: 'magic' }))
-      .to.throw(TypeError);
+    expect(() => new Request('POST', url, { compression: 'magic' })).to.throw(
+      TypeError
+    );
   });
 
   it('Supports query string parameters in URL', () => {
     url = 'https://httpbin.org/get?foo=bar&baz';
     request = new Request('GET', url, { json: true });
 
-    return request.run()
-      .then(response => {
-        expect(response.args.foo).to.equal('bar');
-      });
+    return request.run().then(response => {
+      expect(response.args.foo).to.equal('bar');
+    });
   });
 
   it('Supports booleans, strings, numbers and undefined in query object', () => {
@@ -185,14 +176,13 @@ describe('Request - test against httpbin.org', () => {
     };
     request = new Request('GET', url, { json: true, qs });
 
-    return request.run()
-      .then(response => {
-        expect(response.args.text).to.equal('test text');
-        expect(response.args.number).to.equal('-1');
-        expect(response.args.boolean).to.equal('false');
-        expect(response.args.undefined).to.exist;
-        expect(response.args.array).to.eql(['1', '2', '3']);
-      });
+    return request.run().then(response => {
+      expect(response.args.text).to.equal('test text');
+      expect(response.args.number).to.equal('-1');
+      expect(response.args.boolean).to.equal('false');
+      expect(response.args.undefined).to.exist;
+      expect(response.args.array).to.eql(['1', '2', '3']);
+    });
   });
 
   it('Accepts custom headers', () => {
@@ -202,10 +192,11 @@ describe('Request - test against httpbin.org', () => {
     };
 
     request = new Request('GET', url, { json: true, headers });
-    return request.run()
-      .then(response => {
-        expect(response.headers['X-Custom-Header']).to.equal(headers['X-Custom-Header']);
-      });
+    return request.run().then(response => {
+      expect(response.headers['X-Custom-Header']).to.equal(
+        headers['X-Custom-Header']
+      );
+    });
   });
 
   it('Interprets empty response with JSON request as null', () => {
@@ -213,10 +204,9 @@ describe('Request - test against httpbin.org', () => {
     url = 'http://httpbin.org/stream/0';
 
     request = new Request('GET', url, { json: true });
-    return request.run()
-      .then(response => {
-        expect(response).to.equal(null);
-      });
+    return request.run().then(response => {
+      expect(response).to.equal(null);
+    });
   });
 
   it('Supports 301-303 redirects', () => {
@@ -226,17 +216,17 @@ describe('Request - test against httpbin.org', () => {
       qs: { url: 'https://httpbin.org/get' },
     });
 
-    return request.run()
-      .then(response => {
-        expect(response).to.exist;
-      });
+    return request.run().then(response => {
+      expect(response).to.exist;
+    });
   });
 
   it('Rejects on 4xx errors', () => {
     url = 'http://httpbin.org/status/418';
     request = new Request('GET', url);
 
-    return request.run()
+    return request
+      .run()
       .catch(error => {
         expect(error.statusCode).to.equal(418);
         expect(error.response).to.match(/teapot/);
@@ -250,7 +240,8 @@ describe('Request - test against httpbin.org', () => {
     url = 'https://httpbin.org/redirect-to?url=https://httpbin.org/get';
     request = new Request('GET', url, { json: true, maxRedirects: 0 });
 
-    return request.run()
+    return request
+      .run()
       .catch(error => {
         expect(error).to.exist;
       })
@@ -269,7 +260,8 @@ describe('Request - test against httpbin.org', () => {
     url = 'https://httpbin.org/basic-auth/user/password';
     request = new Request('GET', url, { json: true, auth });
 
-    return request.run()
+    return request
+      .run()
       .then(response => {
         expect(response.authenticated).to.equal(true);
       })
@@ -283,68 +275,110 @@ describe('Request - test against httpbin.org', () => {
     url = 'https://httpbin.org/gzip';
     request = new Request('GET', url, { json: true, compression: ['gzip'] });
 
-    return request.run()
-      .then(response => {
-        expect(response.gzipped).to.equal(true);
-      });
+    return request.run().then(response => {
+      expect(response.gzipped).to.equal(true);
+    });
   });
 
   it('Supports Deflate compression', () => {
     url = 'https://httpbin.org/deflate';
     request = new Request('GET', url, { json: true, compression: ['deflate'] });
 
-    return request.run()
-      .then(response => {
-        expect(response.deflated).to.equal(true);
-      });
+    return request.run().then(response => {
+      expect(response.deflated).to.equal(true);
+    });
   });
 
   it('Supports null options', () => {
     url = 'https://httpbin.org/get';
     request = new Request('GET', url);
 
-    return request.run()
-      .then(response => {
-        expect(response).to.exist;
-      });
+    return request.run().then(response => {
+      expect(response).to.exist;
+    });
   });
 
-  it('Supports \'json\' in options', () => {
+  it("Supports 'json' in options", () => {
     url = 'http://httpbin.org/post';
     body = { foo: 'bar' };
     request = new Request('POST', url, { json: true, body });
 
-    return request.run()
-      .then(response => {
-        expect(JSON.parse(response.data).foo).to.equal('bar');
-      });
+    return request.run().then(response => {
+      expect(JSON.parse(response.data).foo).to.equal('bar');
+    });
   });
 
-  it('Supports \'form\' in options (x-www-form-urlencoded)', () => {
+  it("Supports 'form' in options (x-www-form-urlencoded)", () => {
     url = 'http://httpbin.org/post';
     body = { foo: 'bar' };
     request = new Request('POST', url, { form: body });
 
-    return request.run()
-      .then(response => {
-        expect(JSON.parse(response.toString()).form.foo).to.equal('bar');
-      });
+    return request.run().then(response => {
+      expect(JSON.parse(response.toString()).form.foo).to.equal('bar');
+    });
   });
 
-  it('Supports \'resolveWithFullResponse\' in options', () => {
+  it("Supports 'resolveWithFullResponse' in options", () => {
     url = 'http://httpbin.org/get';
-    request = new Request('GET', url,
-      { json: true, resolveWithFullResponse: true });
+    request = new Request('GET', url, {
+      json: true,
+      resolveWithFullResponse: true,
+    });
 
-    return request.run()
-      .then(response => {
-        expect(response.statusCode).to.equal(200);
-        expect(response.body).to.exist;
+    return request.run().then(response => {
+      expect(response.statusCode).to.equal(200);
+      expect(response.body).to.exist;
+    });
+  });
+
+  xit("Supports 'multipart' bodies", () => null);
+
+  it("Supports 'verbose' in options", () => {
+    url = 'http://httpbin.org/post';
+    body = { foo: 'bar' };
+    request = new Request('POST', url, { json: true, body, verbose: true });
+
+    // Mock console.info && save all values to array
+    // TODO This is less than elegant, but works
+    const oldInfo = console.info;
+    const buffer = [];
+    console.info = (key, value) => {
+      buffer.push(key, value);
+    };
+
+    return request
+      .run()
+      .catch(error => {
+        console.info = oldInfo;
+        throw error;
+      })
+      .then(() => {
+        console.info = oldInfo;
+        expect(buffer).to.not.be.empty;
       });
   });
 
-  xit('Supports \'multipart\' bodies', () => null);
+  it('Supports custom loggers', () => {
+    let count = 0;
+    const logger = {
+      debug: () => {
+        count += 1;
+      },
+    };
 
+    url = 'http://httpbin.org/post';
+    body = { foo: 'bar' };
+    request = new Request('POST', url, {
+      json: true,
+      body,
+      verbose: true,
+      logger,
+    });
+
+    return request.run().then(() => {
+      expect(count).to.be.above(0);
+    });
+  });
 });
 
 describe('Options handling', () => {
@@ -418,26 +452,28 @@ describe('Error handling', () => {
 
   it('Throws TypeError if no protocol given', () => {
     url = 'httpbin.org/get';
-    expect(() => new Request('GET', url, { json: true }))
-      .to.throw(TypeError);
+    expect(() => new Request('GET', url, { json: true })).to.throw(TypeError);
   });
 
   it('Throws TypeError on invalid form data', () => {
     url = 'https://httpbin.org/get';
-    expect(() => new Request('POST', url, { form: 'invalidForm' }))
-      .to.throw(TypeError);
+    expect(() => new Request('POST', url, { form: 'invalidForm' })).to.throw(
+      TypeError
+    );
   });
 
   it('Throws TypeError on invalid auth data', () => {
     url = 'https://httpbin.org/get';
-    expect(() => new Request('POST', url, { auth: 'invalidForm' }))
-      .to.throw(TypeError);
+    expect(() => new Request('POST', url, { auth: 'invalidForm' })).to.throw(
+      TypeError
+    );
   });
 
   it('Throws TypeError on invalid compression scheme', () => {
     url = 'https://httpbin.org/get';
-    expect(() => new Request('POST', url, { compression: 'magic' }))
-      .to.throw(TypeError);
+    expect(() => new Request('POST', url, { compression: 'magic' })).to.throw(
+      TypeError
+    );
   });
 
   it('Throws TypeError when constructing with an invalid method', () => {
@@ -447,7 +483,9 @@ describe('Error handling', () => {
 
   it('Throws TypeError when constructing with an invalid query string', () => {
     url = 'http://httpbin.org/get';
-    expect(() => new Request('GET', url, { qs: 'invalid', json: true })).to.throw(TypeError);
+    expect(
+      () => new Request('GET', url, { qs: 'invalid', json: true })
+    ).to.throw(TypeError);
   });
 
   it('Throws TypeError when constructing with an invalid protocol', () => {
@@ -465,56 +503,67 @@ describe('Error handling', () => {
     url = 'http://foo.not.com/';
     request = new Request('POST', url, { json: true, body });
 
-    return request.run()
+    return request
+      .run()
       .then(
-        () => (expect('should not succeed').to.equal(true)),
-        error => (expect(error).to.be.instanceof(ConnectionError))
+        () => expect('should not succeed').to.equal(true),
+        error => expect(error).to.be.instanceof(ConnectionError)
       );
   });
 
   it('Throws ConnectionError when client aborted', () => {
     url = 'http://httpbin.org/get';
-    ProxiedRequest = createConnectionErrorStub('abort', new Error('Connection aborted'));
+    ProxiedRequest = createConnectionErrorStub(
+      'abort',
+      new Error('Connection aborted')
+    );
     request = new ProxiedRequest('GET', url, { json: true });
 
-    return request.run()
-      .then(
-        () => (expect('should not succeed').to.equal(true)),
-        error => {
-          expect(error).to.be.instanceof(ConnectionError);
-          expect(error.message).to.equal('Connection failed: Client aborted the request');
-        }
-      );
+    return request.run().then(
+      () => expect('should not succeed').to.equal(true),
+      error => {
+        expect(error).to.be.instanceof(ConnectionError);
+        expect(error.message).to.equal(
+          'Connection failed: Client aborted the request'
+        );
+      }
+    );
   });
 
   it('Throws ConnectionError when server aborted', () => {
     url = 'http://httpbin.org/get';
-    ProxiedRequest = createConnectionErrorStub('aborted', new Error('Connection aborted'));
+    ProxiedRequest = createConnectionErrorStub(
+      'aborted',
+      new Error('Connection aborted')
+    );
     request = new ProxiedRequest('GET', url, { json: true });
 
-    return request.run()
-      .then(
-        () => (expect('should not succeed').to.equal(true)),
-        error => {
-          expect(error).to.be.instanceof(ConnectionError);
-          expect(error.message).to.equal('Connection failed: Server aborted the request');
-        }
-      );
+    return request.run().then(
+      () => expect('should not succeed').to.equal(true),
+      error => {
+        expect(error).to.be.instanceof(ConnectionError);
+        expect(error.message).to.equal(
+          'Connection failed: Server aborted the request'
+        );
+      }
+    );
   });
 
   it('Throws ConnectionError on other errors', () => {
     url = 'http://httpbin.org/get';
-    ProxiedRequest = createConnectionErrorStub('error', new Error('Some other error'));
+    ProxiedRequest = createConnectionErrorStub(
+      'error',
+      new Error('Some other error')
+    );
     request = new ProxiedRequest('GET', url, { json: true });
 
-    return request.run()
-      .then(
-        () => (expect('should not succeed').to.equal(true)),
-        error => {
-          expect(error).to.be.instanceof(ConnectionError);
-          expect(error.message).to.equal('Connection failed: Some other error');
-        }
-      );
+    return request.run().then(
+      () => expect('should not succeed').to.equal(true),
+      error => {
+        expect(error).to.be.instanceof(ConnectionError);
+        expect(error.message).to.equal('Connection failed: Some other error');
+      }
+    );
   });
 
   it('Throws HTTP on HTTP Error code responses 4xx-5xx', () => {
@@ -525,26 +574,24 @@ describe('Error handling', () => {
     });
     request = new ProxiedRequest('GET', url, { json: true });
 
-    return request.run()
-      .then(
-        () => (expect('should not succeed').to.equal(true)),
-        error => {
-          expect(error).to.be.instanceof(HTTPError);
-          expect(error.toString()).to.equal('500: Error in response');
-        }
-      );
+    return request.run().then(
+      () => expect('should not succeed').to.equal(true),
+      error => {
+        expect(error).to.be.instanceof(HTTPError);
+        expect(error.toString()).to.equal('500: Error in response');
+      }
+    );
   });
 
   it('Throws ParseError when requesting JSON, but getting sth else', () => {
     url = 'http://httpbin.org/bytes/1024';
     request = new Request('GET', url, { json: true });
 
-    return request.run()
-      .then(
-        () => (expect('should not succeed').to.equal(true)),
-        error => {
-          expect(error).to.be.instanceof(ParseError);
-        }
-      );
+    return request.run().then(
+      () => expect('should not succeed').to.equal(true),
+      error => {
+        expect(error).to.be.instanceof(ParseError);
+      }
+    );
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('request-promise-light', function () {
+describe('request-promise-lite', function () {
   this.timeout(10000);
 
   require('./StreamReaderSpec.js');


### PR DESCRIPTION
This should fix the problem by supporting both custom loggers and falling back to DefaultLogger that respects the 'verbose' flag.