### PR TITLE
FIX #21: Support for timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ are passed forward as-is. In addition the following shorthand options are suppor
   json: false, // JSON shortcut for req headers & response parsing
   logger: new ConsoleLogger(), // An object that consumes the logging requests
   maxRedirects: 3, // How many redirects to follow
+  qs: {}, // The query string parameters to send
   resolveWithFullResponse: false, // Resolve with the response, not the body
+  timeout: 0, // The socket timeout (0 refers to disabled)
   verbose: false, // Run the requests in verbose mode (produces logs)
 };
 ```
@@ -106,80 +108,81 @@ This module already supports a wealth of options. An acceptance test run tells
 the situation best:
 
 ```
-StreamReader
-  ✓ Reads a stream fully
-  ✓ Reads a that has been chunked by individual writes
-  ✓ Fails gracefully on invalid stream
-ParseError
-  ✓ Supports message, status code and response
-  ✓ is an an instance of RequestError
-HTTPError
-  ✓ Supports message, status code and response
-  ✓ Stringifies to a meaningful message
-  ✓ is an an instance of RequestError
-ConnectionError
-  ✓ Supports message and raw message
-  ✓ Stringifies to a meaningful message
-  ✓ is an an instance of RequestError
-Request - test against httpbin.org
-  ✓ Supports HTTP (268ms)
-  ✓ Supports HTTPS (575ms)
-  - Performs TRACE requests
-  ✓ Performs HEAD requests (255ms)
-  ✓ Performs OPTIONS requests (295ms)
-  ✓ Performs GET requests (258ms)
-  ✓ Performs POST requests (1255ms)
-  ✓ Performs PUT requests (284ms)
-  ✓ Performs PATCH requests (247ms)
-  ✓ Performs DELETE requests (254ms)
-  ✓ Fails with TypeError if no protocol given
-  ✓ Fails with TypeError on invalid form data
-  ✓ Fails with TypeError on invalid auth data
-  ✓ Fails with TypeError on invalid compression scheme
-  ✓ Supports query string parameters in URL (512ms)
-  ✓ Supports booleans, strings, numbers and undefined in query object (519ms)
-  ✓ Accepts custom headers (528ms)
-  ✓ Interprets empty response with JSON request as null (272ms)
-  ✓ Supports 301-303 redirects (1014ms)
-  ✓ Rejects on 4xx errors (259ms)
-  ✓ Limits the maximum number of 301-303 redirects (520ms)
-  ✓ Supports TLS with passphrase
-  ✓ Supports HTTP Basic Auth (513ms)
-  ✓ Supports GZIP compression (516ms)
-  ✓ Supports Deflate compression (554ms)
-  ✓ Supports null options (524ms)
-  ✓ Supports 'json' in options (393ms)
-  ✓ Supports 'form' in options (x-www-form-urlencoded) (317ms)
-  ✓ Supports 'resolveWithFullResponse' in options (259ms)
-  - Supports 'multipart' bodies
-  ✓ Supports 'verbose' in options (1260ms)
-  ✓ Supports custom loggers (263ms)
-Options handling
-  ✓ Overrides built-in defaults by RPL_DEFAULTS env variable
-  ✓ Overrides built-in & env defaults by Request.defaults variable
-  ✓ Resets the static defaults when set to {} or null
-Error handling
-  ✓ Throws TypeError if no protocol given
-  ✓ Throws TypeError on invalid form data
-  ✓ Throws TypeError on invalid auth data
-  ✓ Throws TypeError on invalid compression scheme
-  ✓ Throws TypeError when constructing with an invalid method
-  ✓ Throws TypeError when constructing with an invalid query string
-  ✓ Throws TypeError when constructing with an invalid protocol
-  ✓ Throws TypeError when constructing with an invalid path
-  ✓ Throws connections to non-existing hosts as ConnectionError
-  ✓ Throws ConnectionError when client aborted
-  ✓ Throws ConnectionError when server aborted
-  ✓ Throws ConnectionError on other errors
-  ✓ Throws HTTP on HTTP Error code responses 4xx-5xx
-  ✓ Throws ParseError when requesting JSON, but getting sth else (259ms)
-index.js wrapper
-  ✓ Nested methods - request.get (257ms)
-  ✓ Nested classes - request.Request (504ms)
-  ✓ Nested classes - request.StreamReader
+  StreamReader
+    ✓ Reads a stream fully
+    ✓ Reads a that has been chunked by individual writes
+    ✓ Fails gracefully on invalid stream
+  ParseError
+    ✓ Supports message, status code and response
+    ✓ is an an instance of RequestError
+  HTTPError
+    ✓ Supports message, status code and response
+    ✓ Stringifies to a meaningful message
+    ✓ is an an instance of RequestError
+  ConnectionError
+    ✓ Supports message and raw message
+    ✓ Stringifies to a meaningful message
+    ✓ is an an instance of RequestError
+  Request - test against httpbin.org
+    ✓ Supports HTTP (292ms)
+    ✓ Supports HTTPS (521ms)
+    - Performs TRACE requests
+    ✓ Performs HEAD requests (713ms)
+    ✓ Performs OPTIONS requests (410ms)
+    ✓ Performs GET requests (269ms)
+    ✓ Performs POST requests (342ms)
+    ✓ Performs PUT requests (306ms)
+    ✓ Performs PATCH requests (243ms)
+    ✓ Performs DELETE requests (240ms)
+    ✓ Fails with TypeError if no protocol given
+    ✓ Fails with TypeError on invalid form data
+    ✓ Fails with TypeError on invalid auth data
+    ✓ Fails with TypeError on invalid compression scheme
+    ✓ Supports query string parameters in URL (664ms)
+    ✓ Supports booleans, strings, numbers and undefined in query object (585ms)
+    ✓ Accepts custom headers (681ms)
+    ✓ Interprets empty response with JSON request as null (445ms)
+    ✓ Supports 301-303 redirects (1124ms)
+    ✓ Rejects on 4xx errors (379ms)
+    ✓ Limits the maximum number of 301-303 redirects (519ms)
+    ✓ Supports TLS with passphrase
+    ✓ Supports HTTP Basic Auth (635ms)
+    ✓ Supports GZIP compression (751ms)
+    ✓ Supports Deflate compression (581ms)
+    ✓ Supports null options (571ms)
+    ✓ Supports 'json' in options (290ms)
+    ✓ Supports 'form' in options (x-www-form-urlencoded) (261ms)
+    ✓ Supports 'resolveWithFullResponse' in options (408ms)
+    - Supports 'multipart' bodies
+    ✓ Supports 'verbose' in options (410ms)
+    ✓ Supports custom loggers (415ms)
+  Options handling
+    ✓ Overrides built-in defaults by RPL_DEFAULTS env variable
+    ✓ Overrides built-in & env defaults by Request.defaults variable
+    ✓ Resets the static defaults when set to {} or null
+  Error handling
+    ✓ Throws TypeError if no protocol given
+    ✓ Throws TypeError on invalid form data
+    ✓ Throws TypeError on invalid auth data
+    ✓ Throws TypeError on invalid compression scheme
+    ✓ Throws TypeError when constructing with an invalid method
+    ✓ Throws TypeError when constructing with an invalid query string
+    ✓ Throws TypeError when constructing with an invalid protocol
+    ✓ Throws TypeError when constructing with an invalid path
+    ✓ Throws connections to non-existing hosts as ConnectionError
+    ✓ Throws ConnectionError when client aborted
+    ✓ Throws ConnectionError when server aborted
+    ✓ Throws ConnectionError on set timeout when the timeout is expired (1127ms)
+    ✓ Throws ConnectionError on other errors
+    ✓ Throws HTTP on HTTP Error code responses 4xx-5xx
+    ✓ Throws ParseError when requesting JSON, but getting sth else (372ms)
+  index.js wrapper
+    ✓ Nested methods - request.get (306ms)
+    ✓ Nested classes - request.Request (614ms)
+    ✓ Nested classes - request.StreamReader
 
 
-61 passing (13s)
+62 passing (15s)
 2 pending
 ```
 

--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -549,6 +549,21 @@ describe('Error handling', () => {
     );
   });
 
+  it('Throws ConnectionError on set timeout when the timeout is expired', () => {
+    url = 'http://httpbin.org/delay/10';
+    request = new Request('GET', url, { json: true, timeout: 1000 });
+
+    return request.run().then(
+      () => expect('should not succeed').to.equal(true),
+      error => {
+        expect(error).to.be.instanceof(ConnectionError);
+        expect(error.message).to.equal(
+          'Connection timed out'
+        );
+      }
+    );
+  });
+
   it('Throws ConnectionError on other errors', () => {
     url = 'http://httpbin.org/get';
     ProxiedRequest = createConnectionErrorStub(
@@ -565,6 +580,7 @@ describe('Error handling', () => {
       }
     );
   });
+
 
   it('Throws HTTP on HTTP Error code responses 4xx-5xx', () => {
     url = 'http://httpbin.org/get';


### PR DESCRIPTION
This adds a 'timeout' option that will be passed into http request options.

This will set a socket connection timeout, but if the socket sends data super slowly, the socket will not time out.