### PR TITLE
Improve logger customizability

### DIFF
--- a/src/ConsoleLogger.js
+++ b/src/ConsoleLogger.js
@@ -18,7 +18,24 @@ export default class ConsoleLogger {
    * @param {...tokens} - The message strings or token values in the messages.
    */
   // eslint-disable-next-line class-methods-use-this
-  debug(...tokens) {
+  log(...tokens) {
     console.info(util.format(...tokens));
+  }
+
+  logRequest(req) {
+    this.log('Request URL: %j', req.url);
+    this.log('Request headers: %j', req.transportOptions.headers);
+    this.log(
+      'Request body: %s',
+      req.body instanceof Buffer ? req.body.toString() : JSON.stringify(req.body)
+    );
+  }
+
+  logResponseHeaders(res) {
+    this.log('Response status: %s', res.statusCode);
+    this.log('Response headers: %j', res.headers);
+  }
+  logResponseBody(body) {
+    this.log('Response body: %s', body instanceof Buffer ? body.toString() : JSON.stringify(body));
   }
 }

--- a/src/Request.js
+++ b/src/Request.js
@@ -316,8 +316,7 @@ export default class Request {
     const _this = this;
 
     if (this.options.verbose) {
-      this.logger.debug('Response status: %s', res.statusCode);
-      this.logger.debug('Response headers: %j', res.headers);
+      this.logger.logResponseHeaders(res, this);
     }
 
     // Handle redirects
@@ -369,9 +368,7 @@ export default class Request {
     return reader.readAll().then(
       body => {
         if (_this.options.verbose) {
-          const decodedBody =
-            body instanceof Buffer ? body.toString() : JSON.stringify(body);
-          _this.logger.debug('Response body: %s', decodedBody);
+          _this.logger.logResponseBody(body, res, this);
         }
 
         // Handle success cases
@@ -402,18 +399,9 @@ export default class Request {
     const _this = this;
 
     return new Promise((resolve, reject) => {
-      const body = _this.body;
 
       if (_this.options.verbose) {
-        const decodedBody =
-          body instanceof Buffer ? body.toString() : JSON.stringify(body);
-
-        _this.logger.debug('Request URL: %j', _this.url);
-        _this.logger.debug(
-          'Request headers: %j',
-          _this.transportOptions.headers
-        );
-        _this.logger.debug('Request body: %s', decodedBody);
+        _this.logger.logRequest(this);
       }
 
       // Choose the transport

--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -361,7 +361,13 @@ describe('Request - test against httpbin.org', () => {
   it('Supports custom loggers', () => {
     let count = 0;
     const logger = {
-      debug: () => {
+      logRequest: () => {
+        count += 1;
+      },
+      logResponseHeaders: () => {
+        count += 1;
+      },
+      logResponseBody: () => {
         count += 1;
       },
     };


### PR DESCRIPTION
Aside of #22 I had a need to improve log output, so it's more friendly for debugging, firstly I thought of improving format that this package proposes, but then I thought that there might be many opinions on right format, so it's probably better if this package provides a mean to customize log messages to any liking.

Therefore I propose to move all log formatting into `ConsoleLogger`. For my cases having that in will also address #22, as then I can decorate messages with ids on my own.

It touches side feature but still it's a breaking change, so I would bump version to v0.14 after that.