### PR TITLE
Add timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ are passed forward as-is. In addition the following shorthand options are suppor
   maxRedirects: 3, // How many redirects to follow
   resolveWithFullResponse: false, // Resolve with the response, not the body
   verbose: false, // Run the requests in verbose mode (produces logs)
+  timeout: 0, // Abort the request if it has not completed within a given number of milliseconds
 };
 ```
 
@@ -170,6 +171,7 @@ Error handling
   ✓ Throws connections to non-existing hosts as ConnectionError
   ✓ Throws ConnectionError when client aborted
   ✓ Throws ConnectionError when server aborted
+  ✓ Throws ConnectionError when the timeout is expired
   ✓ Throws ConnectionError on other errors
   ✓ Throws HTTP on HTTP Error code responses 4xx-5xx
   ✓ Throws ParseError when requesting JSON, but getting sth else (259ms)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "request-promise-lite",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Lightweight, promiseful http/https request client",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/src/Request.js
+++ b/src/Request.js
@@ -19,6 +19,7 @@ const BUILTIN_DEFAULTS = {
   maxRedirects: 3, // How many redirects to follow
   resolveWithFullResponse: false, // Resolve with the response, not the body
   verbose: false, // Run the requests in verbose mode (produces logs)
+  timeout: 0, // Abort the request if it has not completed within a given number of milliseconds
 };
 let USER_DEFAULTS = {};
 
@@ -204,6 +205,7 @@ export default class Request {
       pfx: options.pfx,
       passphrase: options.passphrase,
       rejectUnauthorized: options.rejectUnauthorized,
+      timeout: options.timeout,
     };
     let body = options.body;
 
@@ -439,6 +441,9 @@ export default class Request {
       req.on('response', response => {
         resolve(response);
       });
+      if (transOpts.timeout > 0) {
+        req.setTimeout(transOpts.timeout, () => req.abort());
+      }
       req.end(this.body);
     });
   }

--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -358,6 +358,25 @@ describe('Request - test against httpbin.org', () => {
       });
   });
 
+  it("Supports 'timeout' in options", () => {
+    url = 'http://httpbin.org/get';
+    request = new Request('GET', url, {
+      json: true,
+      resolveWithFullResponse: true,
+      timeout: 10,
+    });
+
+    return request.run().then(
+      () => expect('should not succeed').to.equal(true),
+      error => {
+        expect(error).to.be.instanceof(ConnectionError);
+        expect(error.message).to.equal(
+          'Connection failed: Client aborted the request'
+        );
+      }
+    );
+  });
+
   it('Supports custom loggers', () => {
     let count = 0;
     const logger = {


### PR DESCRIPTION
Add an option to specify a timeout on the connection. The request will be aborted if it has not been completed in the given number of milliseconds.

The timeout defaults to `0`, i.e. no timeout.

See issue: https://github.com/laurisvan/request-promise-lite/issues/21