### PR TITLE
bugfix: don't leak sockets when handling redirects, and honor provide…

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -198,6 +198,7 @@ export default class Request {
     // Form the transport options from input options
     const transOpts = {
       method,
+      agent: options.agent,
       hostname: url.hostname,
       port: url.port,
       path: url.path,
@@ -326,6 +327,7 @@ export default class Request {
     if (status >= 301 && status <= 303) {
       const location = res.headers.location;
       const options = _this.options;
+      res.resume();
 
       // If we're out of the redirect quota, reject
       if (options.maxRedirects < 1) {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -10,6 +10,7 @@
     "strict": [2, "global"],
     "lines-around-directive": 0,
     "func-names": 0,
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "prefer-rest-params": 0
    }
 }

--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -2,6 +2,9 @@
 
 const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
+const http = require('http');
+const https = require('https');
+const net = require('net');
 const EventEmitter = require('events').EventEmitter;
 const Stream = require('stream');
 const Request = require('../lib/Request');
@@ -209,15 +212,38 @@ describe('Request - test against httpbin.org', () => {
     });
   });
 
-  it('Supports 301-303 redirects', () => {
-    url = 'https://httpbin.org/redirect-to';
-    request = new Request('GET', url, {
-      json: true,
-      qs: { url: 'https://httpbin.org/get' },
+  it('Honors http agent provided by user', () => {
+    const callTrace = [];
+    const agent = new http.Agent();
+    agent.createConnection = (...args) => {
+      callTrace.push(1);
+      return net.createConnection(...args);
+    };
+    request = new Request('GET', 'http://httpbin.org/get', {
+      agent,
     });
 
     return request.run().then(response => {
       expect(response).to.exist;
+      expect(callTrace).to.have.lengthOf(1);
+    });
+  });
+
+  it('Supports 301-303 redirects', () => {
+    url = 'https://httpbin.org/redirect-to';
+    const keepAliveAgent = new https.Agent({ keepAlive: true });
+    request = new Request('GET', url, {
+      json: true,
+      qs: { url: 'https://httpbin.org/get' },
+      agent: keepAliveAgent,
+    });
+
+
+    return request.run().then(response => {
+      expect(response).to.exist;
+      const socketName = keepAliveAgent.getName({ host: 'httpbin.org', port: 443 });
+      expect(keepAliveAgent.freeSockets[socketName]).to.have.lengthOf(2);
+      expect(keepAliveAgent.sockets[socketName]).to.not.exist;
     });
   });
 

--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -215,9 +215,9 @@ describe('Request - test against httpbin.org', () => {
   it('Honors http agent provided by user', () => {
     const callTrace = [];
     const agent = new http.Agent();
-    agent.createConnection = (...args) => {
+    agent.createConnection = function () {
       callTrace.push(1);
-      return net.createConnection(...args);
+      return net.createConnection.apply(null, arguments);
     };
     request = new Request('GET', 'http://httpbin.org/get', {
       agent,


### PR DESCRIPTION
…d http agent

When handling a 302 redirect response with keepAlive option, the response body
must be fully read to allow the socket to be put in the 'free socket' bucket of
the http agent.  Otherwise it stays open for ever.

Additionally, the agent provided in the user options was not transmitted to the
http/https request() call.